### PR TITLE
Fix notification subscription and update to new portbase/info package

### DIFF
--- a/notifier/main.go
+++ b/notifier/main.go
@@ -23,6 +23,7 @@ var (
 	dataDir          string
 	databaseDir      string
 	printStackOnExit bool
+	showVersion      bool
 
 	apiClient = client.NewClient("127.0.0.1:817")
 
@@ -34,6 +35,7 @@ func init() {
 	flag.StringVar(&dataDir, "data", "", "set data directory")
 	flag.StringVar(&databaseDir, "db", "", "alias to --data (deprecated)")
 	flag.BoolVar(&printStackOnExit, "print-stack-on-exit", false, "prints the stack before of shutting down")
+	flag.BoolVar(&showVersion, "version", false, "show version and exit")
 
 	runtime.GOMAXPROCS(2)
 }
@@ -58,8 +60,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	// print version
-	if info.PrintVersion() {
+	if showVersion {
+		fmt.Println(info.FullVersion())
 		os.Exit(0)
 	}
 

--- a/notifier/notify.go
+++ b/notifier/notify.go
@@ -20,10 +20,12 @@ var (
 )
 
 func notifClient() {
-	actionListener()
-
 	notifOp := apiClient.Qsub(fmt.Sprintf("query %s", dbNotifBasePath), handleNotification)
 	notifOp.EnableResuscitation()
+
+	// start the action listener and block
+	// until it's closed.
+	actionListener()
 }
 
 func handleNotification(m *client.Message) {


### PR DESCRIPTION
This PR fixes a bug that causes notifications to not be handled (not even subscribed) because the action listener and handler blocks. Thus, the subscription for new notifications has never been placed. In addition, this PR updates the notifier to support the new safing/portbase info package that moved some of the info flag handling to a dedicated modul an unexported `PrintVersion()`.  