### PR TITLE
Wrap settings into next line on small screens

### DIFF
--- a/modules/base/package-lock.json
+++ b/modules/base/package-lock.json
@@ -4953,9 +4953,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {

--- a/modules/base/src/components/options/Option.vue
+++ b/modules/base/src/components/options/Option.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row" style="margin-top: 0px;">
+  <div class="row" style="margin-top: 0px; justify-content: space-around;">
     <div class=" column" style="text-align: left;">
       <h5>
         <span
@@ -355,5 +355,12 @@ export default {
     text-align: left;
     white-space: pre-wrap; // respect \n
   }
+}
+
+@media (max-width: 1100px) { 
+  div.row > div:first-of-type {
+    // force wrap after title/help
+    flex-basis: 100%; 
+  } 
 }
 </style>

--- a/modules/base/src/components/options/Option.vue
+++ b/modules/base/src/components/options/Option.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row" style="margin-top: 0px; justify-content: space-around;">
+  <div class="row" style="margin-top: 0px; justify-content: space-between;">
     <div class=" column" style="text-align: left;">
       <h5>
         <span
@@ -355,6 +355,10 @@ export default {
     text-align: left;
     white-space: pre-wrap; // respect \n
   }
+}
+
+div.row > div {
+  flex-grow: 1;
 }
 
 @media (max-width: 1100px) { 


### PR DESCRIPTION
This is fixes #61 by forcing the settings row to wrap if the screen size is smaller than 1100px. In the long term, the whole UI should be come responsive anyway.