### PR TITLE
Windows notifications replaced Wintoast library

### DIFF
--- a/notifier/go.mod
+++ b/notifier/go.mod
@@ -4,11 +4,9 @@ go 1.18
 
 require (
 	fyne.io/systray v1.9.1-0.20220515191230-b479fb2893c9
-	github.com/Microsoft/go-winio v0.5.2
 	github.com/dhaavi/go-notify v0.0.0-20190209221809-c404b1f22435
 	github.com/safing/portbase v0.14.2
 	github.com/tevino/abool v1.2.0
-	golang.org/x/text v0.3.7
 )
 
 require (

--- a/notifier/go.mod
+++ b/notifier/go.mod
@@ -11,7 +11,10 @@ require (
 	golang.org/x/text v0.3.7
 )
 
-require golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
+require (
+	golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
+)
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
@@ -29,6 +32,5 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/notifier/go.sum
+++ b/notifier/go.sum
@@ -1,5 +1,3 @@
-fyne.io/systray v1.9.1-0.20220504210505-28f121f95e64 h1:QZtt/rxWBVfzFgyVtic1oPUTVlHZobc0pTwhi5uoN5k=
-fyne.io/systray v1.9.1-0.20220504210505-28f121f95e64/go.mod h1:N4ZU0i34X+n8soFRlBNkmJTunw9wD+9jIP19fSZpjSI=
 fyne.io/systray v1.9.1-0.20220515191230-b479fb2893c9 h1:x+mY3LkhrXaWaY1pU008msQ2qCL7a55TvE3F4d5kt9g=
 fyne.io/systray v1.9.1-0.20220515191230-b479fb2893c9/go.mod h1:N4ZU0i34X+n8soFRlBNkmJTunw9wD+9jIP19fSZpjSI=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
@@ -109,6 +107,8 @@ github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hM
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
+github.com/vitaminwater/cgo.wchar v0.0.0-20160320123332-5dd6f4be3f2a h1:ob45GSHxZJ5H2Sf8WzcJWqNmqiBLr2QIHmun1its9d4=
+github.com/vitaminwater/cgo.wchar v0.0.0-20160320123332-5dd6f4be3f2a/go.mod h1:2DpU0Ek6K9QFbDyQwPa3PAOPSfdp38Pk+MXM6y/sDR0=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/notifier/go.sum
+++ b/notifier/go.sum
@@ -2,8 +2,6 @@ fyne.io/systray v1.9.1-0.20220515191230-b479fb2893c9 h1:x+mY3LkhrXaWaY1pU008msQ2
 fyne.io/systray v1.9.1-0.20220515191230-b479fb2893c9/go.mod h1:N4ZU0i34X+n8soFRlBNkmJTunw9wD+9jIP19fSZpjSI=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
-github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VictoriaMetrics/metrics v1.18.1/go.mod h1:ArjwVz7WpgpegX/JpB0zpNF2h2232kErkEnzH1sxMmA=
 github.com/aead/serpent v0.0.0-20160714141033-fba169763ea6/go.mod h1:3HgLJ9d18kXMLQlJvIY3+FszZYMxCz8WfE2MQ7hDY0w=
@@ -76,7 +74,6 @@ github.com/seehuhn/fortuna v1.0.1/go.mod h1:LX8ubejCnUoT/hX+1aKUtbKls2H6DRkqzkc7
 github.com/seehuhn/sha256d v1.0.0/go.mod h1:PEuxg9faClSveVuFXacQmi+NtDI/PX8bpKjtNzf2+s4=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -107,8 +104,6 @@ github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hM
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
-github.com/vitaminwater/cgo.wchar v0.0.0-20160320123332-5dd6f4be3f2a h1:ob45GSHxZJ5H2Sf8WzcJWqNmqiBLr2QIHmun1its9d4=
-github.com/vitaminwater/cgo.wchar v0.0.0-20160320123332-5dd6f4be3f2a/go.mod h1:2DpU0Ek6K9QFbDyQwPa3PAOPSfdp38Pk+MXM6y/sDR0=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
@@ -130,11 +125,9 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -145,7 +138,6 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/notifier/main.go
+++ b/notifier/main.go
@@ -247,8 +247,8 @@ func detectInstallationDir() string {
 		return ""
 	}
 
-	parent := filepath.Dir(exePath)
-	stableJSONFile := filepath.Join(parent, "updates", "stable.json")
+	parent := filepath.Dir(exePath)                                    // parent should be "...\updates\windows_amd64\notifier"
+	stableJSONFile := filepath.Join(parent, "..", "..", "stable.json") // "...\updates\stable.json"
 	stat, err := os.Stat(stableJSONFile)
 	if err != nil {
 		return ""

--- a/notifier/main.go
+++ b/notifier/main.go
@@ -48,7 +48,7 @@ var (
 			"https://updates.safing.io",
 		},
 		DevMode: false,
-		Online:  true, // is disabled later based on command
+		Online:  false, // disable download of resources (this is job for the core).
 	}
 )
 
@@ -108,9 +108,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to start logging: %s\n", err)
 		os.Exit(1)
 	}
-
-	// disable download of resources (this is job for the core).
-	registry.Online = false
 
 	// load registry
 	err = configureRegistry(true)

--- a/notifier/main.go
+++ b/notifier/main.go
@@ -109,10 +109,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// disable download of resources (this is job for the core).
+	registry.Online = false
+
 	// load registry
 	err = configureRegistry(true)
 	if err != nil {
-		log.Errorf("failed to load registry: %s\n", err)
+		fmt.Fprintf(os.Stderr, "failed to load registry: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/notifier/notification.go
+++ b/notifier/notification.go
@@ -60,7 +60,7 @@ type Notification struct {
 	Category string
 	// Message is the default message shown to the user if no localized version
 	// of the notification is available. Note that the message should already
-	// have any paramerized values replaced.
+	// have any parametrized values replaced.
 	Message string
 	// ShowOnSystem specifies if the notification should be also shown on the
 	// operating system. Notifications shown on the operating system level are

--- a/notifier/notification.go
+++ b/notifier/notification.go
@@ -87,8 +87,8 @@ type Notification struct {
 	// based on the user selection.
 	SelectedActionID string
 
-	// systemID holds the ID returned by the dbus interface on Linux.
-	systemID uint32
+	// systemID holds the ID returned by the dbus interface on Linux or by WinToast library on Windows.
+	systemID NotificationID
 }
 
 // Action describes an action that can be taken for a notification.

--- a/notifier/notify_linux.go
+++ b/notifier/notify_linux.go
@@ -8,10 +8,12 @@ import (
 	"github.com/safing/portbase/log"
 )
 
+type NotificationID uint32
+
 var (
 	capabilities notify.Capabilities
 
-	notifsByID     = make(map[uint32]*Notification)
+	notifsByID     = make(map[NotificationID]*Notification)
 	notifsByIDLock sync.Mutex
 )
 
@@ -43,6 +45,9 @@ func handleActions(ctx context.Context, actions chan notify.Signal) {
 				if ok {
 					n.SelectAction(sig.ActionKey)
 				}
+			} else {
+				// Global action invoked, start the app
+				launchApp()
 			}
 		}
 	}

--- a/notifier/notify_linux.go
+++ b/notifier/notify_linux.go
@@ -32,7 +32,7 @@ func handleActions(ctx context.Context, actions chan notify.Signal) {
 		case <-ctx.Done():
 			return
 		case sig := <-actions:
-			log.Tracef("notify: recevied signal: %+v", sig)
+			log.Tracef("notify: received signal: %+v", sig)
 			if sig.ActionKey != "" {
 				// get notification by system ID
 				notifsByIDLock.Lock()

--- a/notifier/notify_linux.go
+++ b/notifier/notify_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	capabilites notify.Capabilities
+	capabilities notify.Capabilities
 
 	notifsByID     = make(map[uint32]*Notification)
 	notifsByIDLock sync.Mutex
@@ -17,7 +17,7 @@ var (
 
 func init() {
 	var err error
-	capabilites, err = notify.GetCapabilities()
+	capabilities, err = notify.GetCapabilities()
 	if err != nil {
 		log.Errorf("failed to get notification system capabilities: %s", err)
 	}
@@ -84,7 +84,7 @@ func (n *Notification) Show() {
 	// The actions send a request message back to the notification client
 	// when invoked.
 	// sysN.Actions []string
-	if capabilites.Actions {
+	if capabilities.Actions {
 		sysN.Actions = make([]string, 0, len(n.AvailableActions)*2)
 		for _, action := range n.AvailableActions {
 			if action.IsSupported() {

--- a/notifier/notify_windows.go
+++ b/notifier/notify_windows.go
@@ -13,7 +13,7 @@ type NotificationID int64
 
 const (
 	appName        = "Portmaster"
-	appUserModelID = "7F00FB48-65D5-4BA8-A35B-F194DA7E1A51"
+	appUserModelID = "io.safing.portmaster"
 )
 
 const (

--- a/notifier/notify_windows.go
+++ b/notifier/notify_windows.go
@@ -3,13 +3,11 @@ package main
 import (
 	"fmt"
 	"sync"
-	"unsafe"
 
 	"github.com/safing/portbase/info"
 	"github.com/safing/portbase/log"
+	"github.com/safing/portmaster-ui/notifier/wintoast"
 	"github.com/safing/portmaster/updates/helper"
-
-	"golang.org/x/sys/windows"
 )
 
 type NotificationID int64
@@ -21,298 +19,154 @@ const (
 	subProduct  = "notifier"
 )
 
-// WinNotify holds the DLL handle.
-type NotifierLib struct {
-	sync.RWMutex
-
-	dll *windows.DLL
-
-	initialize           *windows.Proc
-	isInitialized        *windows.Proc
-	createNotification   *windows.Proc
-	deleteNotification   *windows.Proc
-	addButton            *windows.Proc
-	setImage             *windows.Proc
-	showNotification     *windows.Proc
-	hideNotification     *windows.Proc
-	setActivatedCallback *windows.Proc
-	setDismissedCallback *windows.Proc
-	setFailedCallback    *windows.Proc
-}
-
-var (
-	lib            *NotifierLib
-	libInitialized bool
-	notifsByID     = make(map[NotificationID]*Notification)
-	notifsByIDLock sync.Mutex
+const (
+	SoundDefault = 0
+	SoundSilent  = 1
+	SoundLoop    = 2
 )
 
-func loadDLL() error {
-	new := &NotifierLib{}
+const (
+	SoundPathDefault = 0
+	// see notification_glue.h if you need more types
+)
 
-	// get dll path
-	dllPath, err := getDllPath()
-	if err != nil {
-		return fmt.Errorf("failed to get path to notifier dll %q", err)
-	}
-	// load dll
-	new.dll, err = windows.LoadDLL(dllPath)
-	if err != nil {
-		return fmt.Errorf("failed to load notifier dll %q", err)
-	}
+var (
+	initOnce           sync.Once
+	lib                *wintoast.WinToast
+	notificationsByIDs sync.Map
+)
 
-	// load functions
-	new.initialize, err = new.dll.FindProc("PortmasterToastInitialize")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastInitialize not found %q", err)
-	}
+func getLib() *wintoast.WinToast {
+	initOnce.Do(func() {
+		dllPath, err := getDllPath()
+		if err != nil {
+			log.Errorf("notify: failed to get dll path: %s", err)
+			return
+		}
+		// Load dll and all the functions
+		newLib, err := wintoast.New(dllPath)
+		if err != nil {
+			log.Errorf("notify: failed to load library: %s", err)
+			return
+		}
 
-	new.isInitialized, err = new.dll.FindProc("PortmasterToastIsInitialized")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastIsInitialized not found %q", err)
-	}
+		// Initialize. This will create or update application shortcut. C:\Users\<user>\AppData\Roaming\Microsoft\Windows\Start Menu\Programs
+		err = newLib.Initialize(appName, company, productName, subProduct, info.GetInfo().Version)
+		if err != nil {
+			log.Errorf("notify: failed to load library: %s", err)
+			return
+		}
 
-	new.createNotification, err = new.dll.FindProc("PortmasterToastCreateNotification")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastCreateNotification not found %q", err)
-	}
+		// library was initialized successfully
+		lib = newLib
 
-	new.deleteNotification, err = new.dll.FindProc("PortmasterToastDeleteNotification")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastDeleteNotification not found %q", err)
-	}
+		// Set callbacks
 
-	new.addButton, err = new.dll.FindProc("PortmasterToastAddButton")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastAddButton not found %q", err)
-	}
+		err = lib.SetCallbacks(notificationActivatedCallback, notificationDismissedCallback, notificationDismissedCallback)
+		if err != nil {
+			log.Warningf("notify: failed to set callbacks: %s", err)
+			return
+		}
+	})
 
-	new.setImage, err = new.dll.FindProc("PortmasterToastSetImage")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastSetImage not found %q", err)
-	}
-
-	new.showNotification, err = new.dll.FindProc("PortmasterToastShow")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastShow not found %q", err)
-	}
-
-	new.setActivatedCallback, err = new.dll.FindProc("PortmasterToastActivatedCallback")
-	if err != nil {
-		return fmt.Errorf("PortmasterActivatedCallback not found %q", err)
-	}
-
-	new.setDismissedCallback, err = new.dll.FindProc("PortmasterToastDismissedCallback")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastDismissedCallback not found %q", err)
-	}
-
-	new.setFailedCallback, err = new.dll.FindProc("PortmasterToastFailedCallback")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastFailedCallback not found %q", err)
-	}
-
-	new.hideNotification, err = new.dll.FindProc("PortmasterToastHide")
-	if err != nil {
-		return fmt.Errorf("PortmasterToastHide not found %q", err)
-	}
-
-	lib = new
-	return nil
+	return lib
 }
-
-// API called functions:
 
 // Show shows the notification.
 func (n *Notification) Show() {
-	if lib == nil {
-		log.Error("notify: library not properly loaded")
+	// Lock notification
+	n.Lock()
+	defer n.Unlock()
+
+	// Create new notification object
+	builder, err := getLib().NewNotification(n.Title, n.Message)
+	if err != nil {
+		log.Errorf("notify: failed to create notification: %s", err)
 		return
 	}
+	// Make sure memory is freed when done
+	defer builder.Delete()
 
-	if !libInitialized {
-		log.Error("notify: not initialized")
-	}
-
-	lib.Lock()
-	defer lib.Unlock()
-
-	title, _ := windows.UTF16PtrFromString(n.Title)
-	message, _ := windows.UTF16PtrFromString(n.Message)
-	titleP := unsafe.Pointer(title)
-	messageP := unsafe.Pointer(message)
-	if lib != nil {
-		// Create new notification object
-		notificationTemplate, _, err := lib.createNotification.Call(uintptr(titleP), uintptr(messageP))
-		if notificationTemplate == 0 {
-			log.Errorf("notify: failed to create notification: %q", err)
-		}
-		// Make sure memory is freed when done
-		defer func() { _, _, _ = lib.deleteNotification.Call(notificationTemplate) }()
-
-		// Set Portmaster icon.
-		iconLocation, err := ensureAppIcon()
+	// Set Portmaster icon.
+	iconLocation, err := ensureAppIcon()
+	if err == nil {
+		err = builder.SetImage(iconLocation)
 		if err != nil {
-			log.Warningf("notify: failed to write icon: %s", err)
+			log.Warningf("notify: failed set icon: %s", err)
 		}
-		iconPathUTF, _ := windows.UTF16PtrFromString(iconLocation)
-		iconPathP := unsafe.Pointer(iconPathUTF)
-		_, _, _ = lib.setImage.Call(notificationTemplate, uintptr(iconPathP))
-
-		// Set all the required actions
-		for _, action := range n.AvailableActions {
-			textUTF, _ := windows.UTF16PtrFromString(action.Text)
-			textP := unsafe.Pointer(textUTF)
-			_, _, _ = lib.addButton.Call(notificationTemplate, uintptr(textP))
-		}
-
-		// Show notification and delete c notification object
-		rc, _, err := lib.showNotification.Call(notificationTemplate)
-		if int64(rc) == -1 {
-			log.Errorf("notify: failed to show notification: %q", err)
-		}
-		n.systemID = NotificationID(rc)
-
-		// Link system id to the notification object
-		notifsByIDLock.Lock()
-		notifsByID[NotificationID(rc)] = n
-		notifsByIDLock.Unlock()
+	} else {
+		log.Warningf("notify: failed to write icon: %s", err)
 	}
+
+	// Set default sound.
+	err = builder.SetSound(SoundDefault, SoundPathDefault)
+	if err != nil {
+		log.Warningf("notify: failed to set sound: %s", err)
+	}
+
+	// Set all the required actions.
+	for _, action := range n.AvailableActions {
+		err = builder.AddButton(action.Text)
+		if err != nil {
+			log.Warningf("notify: failed to add button: %s", err)
+		}
+	}
+
+	// Show notification.
+	id, err := builder.Show()
+	if err != nil {
+		log.Errorf("notify: failed to show notification: %s", err)
+		return
+	}
+	n.systemID = NotificationID(id)
+
+	// Link system id to the notification object
+	notificationsByIDs.Store(NotificationID(id), n)
 }
 
 // Cancel cancels the notification.
 func (n *Notification) Cancel() {
-	if lib == nil {
-		log.Errorf("notify: notification library not properly loaded")
+	// Lock notification
+	n.Lock()
+	defer n.Unlock()
+
+	// No need to check for errors. If it fails it is probably already dismissed
+	_ = getLib().HideNotification(int64(n.systemID))
+
+	notificationsByIDs.Delete(n.systemID)
+}
+
+func notificationActivatedCallback(id int64, actionIndex int32) {
+	if actionIndex == -1 {
+		// The user clicked on the notification (not a button), open the portmaster and delete
+		launchApp()
+		notificationsByIDs.Delete(NotificationID(id))
 		return
 	}
 
-	if !libInitialized {
-		log.Error("notify: not initialized")
-	}
-
-	lib.Lock()
-	defer lib.Unlock()
-
-	// the hide function deletes the notification
-	_, _, _ = lib.hideNotification.Call(uintptr(n.systemID))
-
-	notifsByIDLock.Lock()
-	delete(notifsByID, n.systemID)
-	notifsByIDLock.Unlock()
-}
-
-func actionListener() {
-	_ = initialize()
-	// making sure that everything is loaded
-	libInitialized = isInitialized()
-	// Block until notified
-	<-mainCtx.Done()
-}
-
-// portmasterNotificationCallback is a callback from the c library
-func portmasterNotificationActivatedCallback(id NotificationID, actionIndex int32) uintptr {
-	// The user clicked on the notification (not a button), open the portmaster
-	if actionIndex == -1 {
-		launchApp()
-		return 0
-	}
-
 	// The user click one of the buttons
-	// Lock for notification map
-	notifsByIDLock.Lock()
-	defer notifsByIDLock.Unlock()
 
 	// Get notified object
-	notification := notifsByID[id]
+	n, ok := notificationsByIDs.LoadAndDelete(NotificationID(id))
+	if !ok {
+		return
+	}
+
+	notification := n.(*Notification)
+
+	notification.Lock()
+	defer notification.Unlock()
 
 	// Set selected action
 	actionID := notification.AvailableActions[actionIndex].ID
 	notification.SelectAction(actionID)
-
-	delete(notifsByID, id)
-	return 0
 }
 
-// portmasterNotificationDismissedCallback is a callback from the c library
-func portmasterNotificationDismissedCallback(id NotificationID, reason int32) uintptr {
-	// Failure or user dismissal of notification
+func notificationDismissedCallback(id int64, reason int32) {
+	// Failure or user dismissed the notification
 	if reason == 0 {
-		notifsByIDLock.Lock()
-		delete(notifsByID, id)
-		notifsByIDLock.Unlock()
+		notificationsByIDs.Delete(NotificationID(id))
 	}
-	return 0
-}
-
-func initialize() bool {
-	// load the c library
-	err := loadDLL()
-	if err != nil {
-		log.Errorf("notify: notification library not properly loaded %s", err)
-		return false
-	}
-
-	lib.Lock()
-	defer lib.Unlock()
-
-	// Initialize all necessary string for the notification meta data
-	appNameUTF, _ := windows.UTF16PtrFromString(appName)
-	companyUTF, _ := windows.UTF16PtrFromString(company)
-	productNameUTF, _ := windows.UTF16PtrFromString(productName)
-	subProductUTF, _ := windows.UTF16PtrFromString(subProduct)
-	versionInfoUTF, _ := windows.UTF16PtrFromString(info.Version())
-
-	// they are needed as unsafe pointers
-	appNameP := unsafe.Pointer(appNameUTF)
-	companyP := unsafe.Pointer(companyUTF)
-	productNameP := unsafe.Pointer(productNameUTF)
-	subProductP := unsafe.Pointer(subProductUTF)
-	versionInfoP := unsafe.Pointer(versionInfoUTF)
-
-	// Initialize notifications
-	rc, _, err := lib.initialize.Call(uintptr(appNameP), uintptr(companyP), uintptr(productNameP), uintptr(subProductP), uintptr(versionInfoP))
-	if rc != 1 {
-		log.Errorf("notify: failed to initialize notification library %q", err)
-		return false
-	}
-
-	// Initialize action callbacks
-	callback := windows.NewCallback(portmasterNotificationActivatedCallback)
-	rc, _, err = lib.setActivatedCallback.Call(callback)
-
-	if rc != 1 {
-		log.Errorf("notify: failed to initialize activated callback %q", err)
-		return false
-	}
-
-	callback = windows.NewCallback(portmasterNotificationDismissedCallback)
-	rc, _, err = lib.setDismissedCallback.Call(callback)
-
-	if rc != 1 {
-		log.Errorf("notify: failed to initialize dismissed callback %q", err)
-		return false
-	}
-
-	callback = windows.NewCallback(portmasterNotificationDismissedCallback)
-	rc, _, err = lib.setFailedCallback.Call(callback)
-
-	if rc != 1 {
-		log.Errorf("notify: failed to initialize failed callback %q", err)
-		return false
-	}
-
-	return true
-}
-
-func isInitialized() bool {
-	if lib == nil {
-		return false
-	}
-	lib.Lock()
-	defer lib.Unlock()
-	rc, _, _ := lib.isInitialized.Call()
-	return rc == 1
 }
 
 func getDllPath() (string, error) {
@@ -327,4 +181,8 @@ func getDllPath() (string, error) {
 		return "", err
 	}
 	return file.Path(), nil
+}
+
+func actionListener() {
+	// Used in the linux implementation
 }

--- a/notifier/notify_windows.go
+++ b/notifier/notify_windows.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/safing/portbase/info"
 	"github.com/safing/portbase/log"
 	"github.com/safing/portmaster-ui/notifier/wintoast"
 	"github.com/safing/portmaster/updates/helper"
@@ -13,10 +12,8 @@ import (
 type NotificationID int64
 
 const (
-	appName     = "Portmaster"
-	company     = "Safing ICS Technologies GmbH"
-	productName = "Portmaster"
-	subProduct  = "notifier"
+	appName        = "Portmaster"
+	appUserModelID = "7F00FB48-65D5-4BA8-A35B-F194DA7E1A51"
 )
 
 const (
@@ -51,7 +48,7 @@ func getLib() *wintoast.WinToast {
 		}
 
 		// Initialize. This will create or update application shortcut. C:\Users\<user>\AppData\Roaming\Microsoft\Windows\Start Menu\Programs
-		err = newLib.Initialize(appName, company, productName, subProduct, info.GetInfo().Version)
+		err = newLib.Initialize(appName, appUserModelID)
 		if err != nil {
 			log.Errorf("notify: failed to load library: %s", err)
 			return
@@ -87,22 +84,11 @@ func (n *Notification) Show() {
 	// Make sure memory is freed when done
 	defer builder.Delete()
 
-	// Set Portmaster icon.
-	iconLocation, err := ensureAppIcon()
-	if err == nil {
-		err = builder.SetImage(iconLocation)
-		if err != nil {
-			log.Warningf("notify: failed set icon: %s", err)
-		}
-	} else {
-		log.Warningf("notify: failed to write icon: %s", err)
-	}
+	// if needed set notification icon
+	// _ = builder.SetImage(iconLocation)
 
-	// Set default sound.
-	err = builder.SetSound(SoundDefault, SoundPathDefault)
-	if err != nil {
-		log.Warningf("notify: failed to set sound: %s", err)
-	}
+	// Leaving the default value for the sound
+	// _ = builder.SetSound(SoundDefault, SoundPathDefault)
 
 	// Set all the required actions.
 	for _, action := range n.AvailableActions {

--- a/notifier/notify_windows.go
+++ b/notifier/notify_windows.go
@@ -108,6 +108,8 @@ func (n *Notification) Show() {
 
 	// Link system id to the notification object
 	notificationsByIDs.Store(NotificationID(id), n)
+
+	log.Debugf("notify: showing notification %q: %d", n.Title, n.systemID)
 }
 
 // Cancel cancels the notification.
@@ -120,6 +122,7 @@ func (n *Notification) Cancel() {
 	_ = getLib().HideNotification(int64(n.systemID))
 
 	notificationsByIDs.Delete(n.systemID)
+	log.Debugf("notify: notification canceled %q: %d", n.Title, n.systemID)
 }
 
 func notificationActivatedCallback(id int64, actionIndex int32) {
@@ -127,6 +130,7 @@ func notificationActivatedCallback(id int64, actionIndex int32) {
 		// The user clicked on the notification (not a button), open the portmaster and delete
 		launchApp()
 		notificationsByIDs.Delete(NotificationID(id))
+		log.Debugf("notify: notification clicked %d", id)
 		return
 	}
 
@@ -146,12 +150,15 @@ func notificationActivatedCallback(id int64, actionIndex int32) {
 	// Set selected action
 	actionID := notification.AvailableActions[actionIndex].ID
 	notification.SelectAction(actionID)
+
+	log.Debugf("notify: notification button cliecked %d button id: %d", id, actionIndex)
 }
 
 func notificationDismissedCallback(id int64, reason int32) {
 	// Failure or user dismissed the notification
 	if reason == 0 {
 		notificationsByIDs.Delete(NotificationID(id))
+		log.Debugf("notify: notification dissmissed %d", id)
 	}
 }
 

--- a/notifier/wintoast/notification_builder.go
+++ b/notifier/wintoast/notification_builder.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package wintoast
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type NotificationBuilder struct {
+	templatePointer uintptr
+	lib             *WinToast
+}
+
+func newNotification(lib *WinToast, title string, message string) (*NotificationBuilder, error) {
+	lib.Lock()
+	defer lib.Unlock()
+
+	titleUTF, _ := windows.UTF16PtrFromString(title)
+	messageUTF, _ := windows.UTF16PtrFromString(message)
+	titleP := unsafe.Pointer(titleUTF)
+	messageP := unsafe.Pointer(messageUTF)
+
+	ptr, _, err := lib.createNotification.Call(uintptr(titleP), uintptr(messageP))
+	if ptr == 0 {
+		return nil, err
+	}
+
+	return &NotificationBuilder{ptr, lib}, nil
+}
+
+func (n *NotificationBuilder) Delete() {
+	if n == nil {
+		return
+	}
+
+	n.lib.Lock()
+	defer n.lib.Unlock()
+
+	_, _, _ = n.lib.deleteNotification.Call(n.templatePointer)
+}
+
+func (n *NotificationBuilder) AddButton(text string) error {
+	n.lib.Lock()
+	defer n.lib.Unlock()
+	textUTF, _ := windows.UTF16PtrFromString(text)
+	textP := unsafe.Pointer(textUTF)
+
+	rc, _, err := n.lib.addButton.Call(n.templatePointer, uintptr(textP))
+	if rc != 1 {
+		return err
+	}
+	return nil
+}
+
+func (n *NotificationBuilder) SetImage(iconPath string) error {
+	n.lib.Lock()
+	defer n.lib.Unlock()
+	pathUTF, _ := windows.UTF16PtrFromString(iconPath)
+	pathP := unsafe.Pointer(pathUTF)
+
+	rc, _, err := n.lib.setImage.Call(n.templatePointer, uintptr(pathP))
+	if rc != 1 {
+		return err
+	}
+	return nil
+}
+
+func (n *NotificationBuilder) SetSound(option int, path int) error {
+	n.lib.Lock()
+	defer n.lib.Unlock()
+
+	rc, _, err := n.lib.setSound.Call(n.templatePointer, uintptr(option), uintptr(path))
+	if rc != 1 {
+		return err
+	}
+	return nil
+}
+
+func (n *NotificationBuilder) Show() (int64, error) {
+	n.lib.Lock()
+	defer n.lib.Unlock()
+
+	id, _, err := n.lib.showNotification.Call(n.templatePointer)
+	if int64(id) == -1 {
+		return -1, err
+	}
+	return int64(id), nil
+}

--- a/notifier/wintoast/wintoast.go
+++ b/notifier/wintoast/wintoast.go
@@ -80,9 +80,9 @@ func New(dllPath string) (*WinToast, error) {
 		return nil, fmt.Errorf("winnotifiy: PortmasterToastSetImage not found %w", err)
 	}
 
-	libraryObject.setSound, err = libraryObject.dll.FindProc("PortmasterToastSetNotificationSound")
+	libraryObject.setSound, err = libraryObject.dll.FindProc("PortmasterToastSetSound")
 	if err != nil {
-		return nil, fmt.Errorf("winnotifiy: PortmasterToastSetNotificationSound not found %w", err)
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastSetSound not found %w", err)
 	}
 
 	libraryObject.showNotification, err = libraryObject.dll.FindProc("PortmasterToastShow")

--- a/notifier/wintoast/wintoast.go
+++ b/notifier/wintoast/wintoast.go
@@ -1,0 +1,223 @@
+//go:build windows
+
+package wintoast
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/safing/portbase/info"
+
+	"github.com/tevino/abool"
+
+	"golang.org/x/sys/windows"
+)
+
+// WinNotify holds the DLL handle.
+type WinToast struct {
+	sync.RWMutex
+
+	dll *windows.DLL
+
+	initialized *abool.AtomicBool
+
+	initialize           *windows.Proc
+	isInitialized        *windows.Proc
+	createNotification   *windows.Proc
+	deleteNotification   *windows.Proc
+	addButton            *windows.Proc
+	setImage             *windows.Proc
+	setSound             *windows.Proc
+	showNotification     *windows.Proc
+	hideNotification     *windows.Proc
+	setActivatedCallback *windows.Proc
+	setDismissedCallback *windows.Proc
+	setFailedCallback    *windows.Proc
+}
+
+func New(dllPath string) (*WinToast, error) {
+	if dllPath == "" {
+		return nil, fmt.Errorf("winnotifiy: path to dll not specified")
+	}
+
+	libraryObject := &WinToast{}
+	libraryObject.initialized = abool.New()
+
+	// load dll
+	var err error
+	libraryObject.dll, err = windows.LoadDLL(dllPath)
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: failed to load notifier dll %w", err)
+	}
+
+	// load functions
+	libraryObject.initialize, err = libraryObject.dll.FindProc("PortmasterToastInitialize")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastInitialize not found %w", err)
+	}
+
+	libraryObject.isInitialized, err = libraryObject.dll.FindProc("PortmasterToastIsInitialized")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastIsInitialized not found %w", err)
+	}
+
+	libraryObject.createNotification, err = libraryObject.dll.FindProc("PortmasterToastCreateNotification")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastCreateNotification not found %w", err)
+	}
+
+	libraryObject.deleteNotification, err = libraryObject.dll.FindProc("PortmasterToastDeleteNotification")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastDeleteNotification not found %w", err)
+	}
+
+	libraryObject.addButton, err = libraryObject.dll.FindProc("PortmasterToastAddButton")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastAddButton not found %w", err)
+	}
+
+	libraryObject.setImage, err = libraryObject.dll.FindProc("PortmasterToastSetImage")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastSetImage not found %w", err)
+	}
+
+	libraryObject.setSound, err = libraryObject.dll.FindProc("PortmasterToastSetNotificationSound")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastSetNotificationSound not found %w", err)
+	}
+
+	libraryObject.showNotification, err = libraryObject.dll.FindProc("PortmasterToastShow")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastShow not found %w", err)
+	}
+
+	libraryObject.setActivatedCallback, err = libraryObject.dll.FindProc("PortmasterToastActivatedCallback")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterActivatedCallback not found %w", err)
+	}
+
+	libraryObject.setDismissedCallback, err = libraryObject.dll.FindProc("PortmasterToastDismissedCallback")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastDismissedCallback not found %w", err)
+	}
+
+	libraryObject.setFailedCallback, err = libraryObject.dll.FindProc("PortmasterToastFailedCallback")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastFailedCallback not found %w", err)
+	}
+
+	libraryObject.hideNotification, err = libraryObject.dll.FindProc("PortmasterToastHide")
+	if err != nil {
+		return nil, fmt.Errorf("winnotifiy: PortmasterToastHide not found %w", err)
+	}
+
+	return libraryObject, nil
+}
+
+func (lib *WinToast) Initialize(appName, company, productName, subProduct, version string) error {
+	if lib == nil {
+		return fmt.Errorf("wintoast: lib object was nil")
+	}
+
+	lib.Lock()
+	defer lib.Unlock()
+
+	// Initialize all necessary string for the notification meta data
+	appNameUTF, _ := windows.UTF16PtrFromString(appName)
+	companyUTF, _ := windows.UTF16PtrFromString(company)
+	productNameUTF, _ := windows.UTF16PtrFromString(productName)
+	subProductUTF, _ := windows.UTF16PtrFromString(subProduct)
+	versionInfoUTF, _ := windows.UTF16PtrFromString(info.Version())
+
+	// They are needed as unsafe pointers
+	appNameP := unsafe.Pointer(appNameUTF)
+	companyP := unsafe.Pointer(companyUTF)
+	productNameP := unsafe.Pointer(productNameUTF)
+	subProductP := unsafe.Pointer(subProductUTF)
+	versionInfoP := unsafe.Pointer(versionInfoUTF)
+
+	// Initialize notifications
+	rc, _, err := lib.initialize.Call(uintptr(appNameP), uintptr(companyP), uintptr(productNameP), uintptr(subProductP), uintptr(versionInfoP))
+	if rc != 1 {
+		return fmt.Errorf("wintoast: failed to initialize library rc = %d, %w", rc, err)
+	}
+
+	// Check if if the initialization was successfully
+	rc, _, err = lib.isInitialized.Call()
+	if rc == 1 {
+		lib.initialized.Set()
+	} else {
+		return fmt.Errorf("wintoast: initialized flag was not set: rc = %d, %w", rc, err)
+	}
+
+	return nil
+}
+
+func (lib *WinToast) SetCallbacks(activated func(id int64, actionIndex int32), dismissed func(id int64, reason int32), failed func(id int64, reason int32)) error {
+	if lib == nil {
+		return fmt.Errorf("wintoast: lib object was nil")
+	}
+
+	if lib.initialized.IsNotSet() {
+		return fmt.Errorf("winnotifiy: library not initialized")
+	}
+
+	// Initialize notification activated callback
+	callback := windows.NewCallback(func(id int64, actionIndex int32) uint64 {
+		activated(id, actionIndex)
+		return 0
+	})
+	rc, _, err := lib.setActivatedCallback.Call(callback)
+	if rc != 1 {
+		return fmt.Errorf("winnotifiy: failed to initialize activated callback %w", err)
+	}
+
+	// Initialize notification dismissed callback
+	callback = windows.NewCallback(func(id int64, actionIndex int32) uint64 {
+		dismissed(id, actionIndex)
+		return 0
+	})
+	rc, _, err = lib.setDismissedCallback.Call(callback)
+	if rc != 1 {
+		return fmt.Errorf("winnotifiy: failed to initialize dismissed callback %w", err)
+	}
+
+	// Initialize notification failed callback
+	callback = windows.NewCallback(func(id int64, actionIndex int32) uint64 {
+		failed(id, actionIndex)
+		return 0
+	})
+	rc, _, err = lib.setFailedCallback.Call(callback)
+	if rc != 1 {
+		return fmt.Errorf("winnotifiy: failed to initialize failed callback %s", err)
+	}
+
+	return nil
+}
+
+// NewNotification starts a creation of new notification. NotificationBuilder.Delete should allays be called when done using the object or there will be memory leeks
+func (lib *WinToast) NewNotification(title string, content string) (*NotificationBuilder, error) {
+	if lib == nil {
+		return nil, fmt.Errorf("wintoast: lib object was nil")
+	}
+	return newNotification(lib, title, content)
+}
+
+// HideNotification hides notification
+func (lib *WinToast) HideNotification(id int64) error {
+	if lib == nil {
+		return fmt.Errorf("wintoast: lib object was nil")
+	}
+
+	lib.Lock()
+	defer lib.Unlock()
+
+	rc, _, _ := lib.hideNotification.Call(uintptr(id))
+
+	if rc != 1 {
+		return fmt.Errorf("wintoast: failed to hide notification %d", id)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Here is a build of the dll if you want to test it. The must be in `updates\windows_amd64\notifier\portmaster-wintoast_v0-1-0.dll`
[portmaster-wintoast_v0-1-0.dll.zip](https://github.com/safing/portmaster-ui/files/9584769/portmaster-wintoast_v0-1-0.dll.zip)

and this line must be added to `stable.json`
 `"windows_amd64/packages/portmaster-wintoast.dll": "0.1.0"`
