### PR TITLE
Add "sort by" to Network Scout

### DIFF
--- a/modules/portmaster/src/app/services/ui-state.service.ts
+++ b/modules/portmaster/src/app/services/ui-state.service.ts
@@ -6,11 +6,13 @@ import { catchError } from "rxjs/operators";
 export interface UIState extends Record {
   hideExitScreen?: boolean;
   introScreenFinished?: boolean;
+  netscoutSortOrder?: string;
 }
 
 const defaultState: UIState = {
   hideExitScreen: false,
-  introScreenFinished: false
+  introScreenFinished: false,
+  netscoutSortOrder: 'A - Z',
 }
 
 @Injectable({ providedIn: 'root' })

--- a/modules/portmaster/src/app/shared/network-scout/network-scout.html
+++ b/modules/portmaster/src/app/shared/network-scout/network-scout.html
@@ -10,7 +10,12 @@
     </svg>
     <span class="text-xxs uppercase text-secondary absolute right-1.5 top-2 font-light">{{allProfiles.length}}
       Apps</span>
-  </div>
+    </div>
+    <sfng-select [(ngModel)]="displayOrder" (ngModelChange)="refreshScout($event)" class="relative auto" itemName="Sort" placeholder="Sort" allowSearch="false">
+      <ng-container *ngFor="let sort of SortMethods | keyvalue" >
+        <sfng-select-item *sfngSelectValue="sort.value">{{ sort.value }}</sfng-select-item>
+      </ng-container>
+    </sfng-select>
 
   <ng-container *ngIf="spnEnabled">
     <svg *ngIf="expandCollapseState === 'expand'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"

--- a/modules/portmaster/src/app/shared/network-scout/network-scout.html
+++ b/modules/portmaster/src/app/shared/network-scout/network-scout.html
@@ -11,7 +11,7 @@
     <span class="text-xxs uppercase text-secondary absolute right-1.5 top-2 font-light">{{allProfiles.length}}
       Apps</span>
     </div>
-    <sfng-select [(ngModel)]="displayOrder" (ngModelChange)="refreshScout($event)" class="relative auto" itemName="Sort" placeholder="Sort" allowSearch="false">
+    <sfng-select [(ngModel)]="displayOrder" (ngModelChange)="handleSortChange()" class="relative auto" itemName="Sort" placeholder="Sort" allowSearch="false">
       <ng-container *ngFor="let sort of SortMethods | keyvalue" >
         <sfng-select-item *sfngSelectValue="sort.value">{{ sort.value }}</sfng-select-item>
       </ng-container>

--- a/modules/portmaster/src/app/shared/network-scout/network-scout.ts
+++ b/modules/portmaster/src/app/shared/network-scout/network-scout.ts
@@ -33,11 +33,14 @@ export class NetworkScoutComponent implements OnInit {
   /** The current search term as entered in the input[type="text"] */
   searchTerm: string = '';
 
+  /** Order of listed elements */
+  displayOrder: string = "A - Z";
+
   /** A list of all active profiles without any search applied */
   allProfiles: _Profile[] = [];
 
   /** Defines if new elements should be expanded or collapsed */
-  expandCollapseState: 'expand' | 'collapse' = 'expand';
+  expandCollapseState: ('expand' | 'collapse') = 'expand';
 
   /** Whether or not the SPN is enabled */
   spnEnabled = false;
@@ -61,6 +64,14 @@ export class NetworkScoutComponent implements OnInit {
   /** TrackByFunction for the exit pins */
   trackPin: TrackByFunction<_Pin> = (_, pin) => pin.ID;
 
+  SortMethods = {
+    aToZ: "A - Z",
+    zToA: "Z - A",
+    TotalConnections: "Total Connections",
+    ConnectionsDenied: "Denied Connections",
+    ConnectionsAllowed: "Allowed Connections",
+  }
+
   constructor(
     private netquery: Netquery,
     private spn: SPNService,
@@ -69,12 +80,30 @@ export class NetworkScoutComponent implements OnInit {
     private cdr: ChangeDetectorRef,
   ) { }
 
+  sortProfiles(profiles: _Profile[]) {
+    const sortMethods = new Map([
+      [this.SortMethods.aToZ, (a: _Profile, b: _Profile) => a.Name.localeCompare(b.Name)],
+      [this.SortMethods.zToA, (a: _Profile, b: _Profile) => b.Name.localeCompare(a.Name)],
+      [this.SortMethods.TotalConnections, (a: _Profile, b: _Profile) => (b.countAllowed + b.countUnpermitted) - (a.countAllowed + a.countUnpermitted)],
+      [this.SortMethods.ConnectionsAllowed, (a: _Profile, b: _Profile) => b.countAllowed - a.countAllowed],
+      [this.SortMethods.ConnectionsDenied, (a: _Profile, b: _Profile) => b.countUnpermitted - a.countUnpermitted],
+    ]);
+
+    const sortingFunc = sortMethods.get(this.displayOrder);
+
+    if (sortingFunc) {
+      profiles.sort(sortingFunc);
+    }
+
+    return profiles;
+  }
+
   searchProfiles(term: string) {
     term = term.trim();
 
     if (term === '') {
       this.profiles = [
-        ...this.allProfiles
+       ...this.sortProfiles(this.allProfiles)
       ];
 
       return;
@@ -96,6 +125,10 @@ export class NetworkScoutComponent implements OnInit {
 
       return false;
     })
+  }
+
+  refreshScout(event: any) {
+    this.cdr.markForCheck();
   }
 
   expandAll() {


### PR DESCRIPTION
I've found it quite odd that there was no way to sort in what order Apps are displayed.
This PR aim's to solve this by adding a Sort button and defaulting to "A - Z".

Previews attached.

![image](https://user-images.githubusercontent.com/52699291/235302071-86d4d314-ecc4-4e6e-879d-1051e1fbebd3.png)
![image](https://user-images.githubusercontent.com/52699291/235302079-1cdf3141-6690-4f9c-b9d9-d5c8db839650.png)
