### PR TITLE
Highlight blocked apps in Network Scout

### DIFF
--- a/modules/portmaster/projects/safing/portmaster-api/src/lib/netquery.service.ts
+++ b/modules/portmaster/projects/safing/portmaster-api/src/lib/netquery.service.ts
@@ -160,6 +160,7 @@ export interface IProfileStats {
   countAllowed: number;
   countUnpermitted: number;
   countAliveConnections: number;
+  allowed: boolean;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -286,6 +287,17 @@ export class Netquery {
             $ne: "",
           },
         },
+      }),
+
+      allowed: this.query({
+        select: [
+          'profile',
+          'allowed'
+        ],
+        groupBy: [
+          'profile'
+        ],
+        query: query
       })
     }).pipe(
       map(result => {
@@ -300,7 +312,8 @@ export class Netquery {
             countUnpermitted: 0,
             empty: true,
             identities: [],
-            size: 0
+            size: 0,
+            allowed: true
           };
 
           statsMap.set(id, stats);
@@ -350,6 +363,11 @@ export class Netquery {
 
           ident.count += res.totalCount;
         })
+
+        result.allowed.forEach(res => {
+          const stats = getOrCreate(res.profile!);
+          stats.allowed = res.allowed!;
+        });
 
         return Array.from(statsMap.values())
       }),

--- a/modules/portmaster/src/app/shared/network-scout/network-scout.html
+++ b/modules/portmaster/src/app/shared/network-scout/network-scout.html
@@ -81,7 +81,7 @@
 <ng-template #header let-data let-active="active" let-accordion="accordion">
   <div class="flex flex-row items-center w-full gap-3 px-3 py-2 bg-gray-200 rounded-sm outline-none"
     [ngClass]="{'cursor-pointer hover:bg-gray-300': !spnEnabled}" [routerLink]="['/app/' + data.ID]"
-    [queryParams]="{tab: 0}" (click)="$event.stopPropagation()">
+    [queryParams]="{tab: 0}" (click)="$event.stopPropagation()" [ngClass]="{'conn-blocked': !data.allowed}">
 
     <svg xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0 w-4 h-4 transition-all duration-150 transform"
       *ngIf="spnEnabled" [class.rotate-90]="active" viewBox="0 0 20 20" fill="currentColor"

--- a/modules/portmaster/src/app/shared/network-scout/network-scout.scss
+++ b/modules/portmaster/src/app/shared/network-scout/network-scout.scss
@@ -1,3 +1,7 @@
 :host {
   @apply w-full p-2 flex flex-col gap-2;
 }
+
+.conn-blocked {
+  background-color: rgba(252, 57, 57, 0.15);
+}


### PR DESCRIPTION
This PR aims to provide a clear overview over what apps are currently not allowed to connect to the Internet by Highlighting them in Red.

![image](https://user-images.githubusercontent.com/52699291/236671784-84b8263f-e0d3-4fc0-bdc3-388a46554d30.png)
