### PR TITLE
Fix Memory Leak in AccordionGroup

### DIFF
--- a/modules/portmaster/projects/safing/ui/src/lib/accordion/accordion-group.ts
+++ b/modules/portmaster/projects/safing/ui/src/lib/accordion/accordion-group.ts
@@ -77,6 +77,22 @@ export class SfngAccordionGroupComponent implements OnDestroy {
     }))
   }
 
+  /**
+   * Unregisters a accordion component
+   *
+   * @param a The accordion component to unregister
+   */
+  unregister(a: SfngAccordionComponent) {
+    const index = this.accordions.indexOf(a);
+    if (index === -1) return;
+  
+    const subscription = this.subscriptions[index];
+  
+    subscription.unsubscribe();
+    this.accordions = this.accordions.splice(index, 1);
+    this.subscriptions = this.subscriptions.splice(index, 1);
+  }
+
   ngOnDestroy() {
     this.subscriptions.forEach(s => s.unsubscribe());
     this.subscriptions = [];

--- a/modules/portmaster/src/app/shared/netquery/netquery.component.html
+++ b/modules/portmaster/src/app/shared/netquery/netquery.component.html
@@ -259,7 +259,7 @@
   <ng-template [sfngPageContent]>
     <sfng-accordion-group class="flex flex-col gap-2 pr-4"
       *ngIf="(paginator.pageLoading$ | async) === false; else: loadingTemplate" [headerTemplate]="headerTemplate"
-      singleMode="false">
+      singleMode="false" #accordionGroup>
       <sfng-accordion [data]="result" #accordion *ngFor="let result of (paginator.pageItems$ | async)">
         <div *ngIf="accordion.active" class="p-3 bg-opacity-75 border-gray-300 rounded-b-sm"
           [ngClass]="{'bg-gray-300 border-t': !result._group}">
@@ -268,7 +268,7 @@
           <ng-container *ngIf="result._group !== null; else: connectionDetails">
             <sfng-accordion-group class="flex flex-col gap-2 ml-4"
               *ngIf="(result._group | async) as connsPaginator; else: loadingTemplate" [headerTemplate]="headerTemplate"
-              singleMode="false">
+              singleMode="false" #accordionGroup>
 
               <div class="flex flex-row items-center p-2 text-secondary" *ngIf="connsPaginator.total === 0">
                 All connections ended more than 10 minutes ago and have been removed.

--- a/modules/portmaster/src/app/shared/netquery/netquery.component.ts
+++ b/modules/portmaster/src/app/shared/netquery/netquery.component.ts
@@ -1,9 +1,9 @@
 import { coerceArray } from "@angular/cdk/coercion";
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, TemplateRef, TrackByFunction, ViewChildren, inject } from "@angular/core";
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, TemplateRef, TrackByFunction, ViewChild, ViewChildren, inject } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ChartResult, Condition, Database, FeatureID, IPScope, Netquery, NetqueryConnection, OrderBy, Pin, PossilbeValue, Query, QueryResult, SPNService, Select, Verdict } from "@safing/portmaster-api";
-import { Datasource, DynamicItemsPaginator, SelectOption } from "@safing/ui";
+import { Datasource, DynamicItemsPaginator, SelectOption, SfngAccordionGroupComponent } from "@safing/ui";
 import { BehaviorSubject, Observable, Subject, combineLatest, forkJoin, interval, of } from "rxjs";
 import { catchError, debounceTime, filter, map, share, skip, switchMap, take, takeUntil } from "rxjs/operators";
 import { ActionIndicatorService } from "../action-indicator";
@@ -106,6 +106,8 @@ interface LocalQueryResult extends QueryResult {
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix
 export class SfngNetqueryViewer implements OnInit, OnDestroy, AfterViewInit {
+  @ViewChild('accordionGroup') accordionGroup!: SfngAccordionGroupComponent;
+
   /** @private Used to trigger a reload of the current filter */
   private search$ = new Subject<void>();
 
@@ -597,6 +599,7 @@ export class SfngNetqueryViewer implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnDestroy() {
+    this.paginator.clear();
     this.search$.complete();
     this.helper.dispose();
   }
@@ -782,6 +785,12 @@ export class SfngNetqueryViewer implements OnInit, OnDestroy, AfterViewInit {
 
   /** @private Query the portmaster service for connections matching the current settings */
   performSearch() {
+    // Prevent a Memory Leak by Deleting all previous accordions.
+    if (typeof this.accordionGroup?.accordions !== 'undefined') {
+      for (let accordion of this.accordionGroup.accordions) {
+        this.accordionGroup.unregister(accordion);
+      }
+    }
     this.loading = true;
     this.lastReload = new Date();
     this.paginator.clear()


### PR DESCRIPTION
Someone thought it'd be a great idea to not unregister accordion elements.
This PR fixes this by adding an unregister function, and clearing all of the accordions when a refresh is triggered.